### PR TITLE
Remove msf constructor wherever possible (fixes #48)

### DIFF
--- a/src/Control/Monad/Trans/MSF/Except.hs
+++ b/src/Control/Monad/Trans/MSF/Except.hs
@@ -184,3 +184,20 @@ step f = try $ proc a -> do
   (b, e) <- arrM (lift . f) -< a
   _      <- throwOn'        -< (n > (1 :: Int), e)
   returnA                   -< b
+
+-- * Utilities definable in terms of 'MSFExcept'
+
+-- TODO This is possibly not the best location for this function,
+-- but moving it back to Data.MonadicStreamFunction.Util would form an import cycle
+-- that could only be broken by moving a few things to Data.MonadicStreamFunction.Core
+-- (that probably belong there anyways).
+
+-- | Extract MSF from a monadic action.
+--
+-- Runs a monadic action that produces an MSF on the first iteration/step, and
+-- uses that MSF as the main signal function for all inputs (including the
+-- first one).
+performOnFirstSample :: Monad m => m (MSF m a b) -> MSF m a b
+performOnFirstSample sfaction = safely $ do
+  msf <- once_ sfaction
+  safe msf

--- a/src/Control/Monad/Trans/MSF/Except.hs
+++ b/src/Control/Monad/Trans/MSF/Except.hs
@@ -187,8 +187,8 @@ step f = try $ proc a -> do
 
 -- * Utilities definable in terms of 'MSFExcept'
 
--- TODO This is possibly not the best location for this function,
--- but moving it back to Data.MonadicStreamFunction.Util would form an import cycle
+-- TODO This is possibly not the best location for these functions,
+-- but moving them to Data.MonadicStreamFunction.Util would form an import cycle
 -- that could only be broken by moving a few things to Data.MonadicStreamFunction.Core
 -- (that probably belong there anyways).
 
@@ -201,3 +201,13 @@ performOnFirstSample :: Monad m => m (MSF m a b) -> MSF m a b
 performOnFirstSample sfaction = safely $ do
   msf <- once_ sfaction
   safe msf
+
+-- | Reactimates an 'MSFExcept' until it throws an exception.
+reactimateExcept :: Monad m => MSFExcept m () () e -> m e
+reactimateExcept msfe = do
+  Left e <- runExceptT $ reactimate $ runMSFExcept msfe
+  return e
+
+-- | Reactimates an 'MSF' until it returns 'True'.
+reactimateB :: Monad m => MSF m () Bool -> m ()
+reactimateB sf = reactimateExcept $ try $ liftMSFTrans sf >>> throwOn ()

--- a/src/Control/Monad/Trans/MSF/Maybe.hs
+++ b/src/Control/Monad/Trans/MSF/Maybe.hs
@@ -57,7 +57,9 @@ untilMaybe msf cond = proc a -> do
   inMaybeT -< if c then Nothing else Just b
 
 -- | When an exception occurs in the first 'msf', the second 'msf' is executed from there.
-catchMaybe :: Monad m => MSF (MaybeT m) a b -> MSF m a b -> MSF m a b
+catchMaybe
+  :: (Functor m, Monad m)
+  => MSF (MaybeT m) a b -> MSF m a b -> MSF m a b
 catchMaybe msf1 msf2 = safely $ do
   _ <- try $ maybeToExceptS msf1
   safe msf2
@@ -107,7 +109,9 @@ runMaybeS'' msf = transS transformInput transformOutput msf
 -}
 
 -- | Reactimates an 'MSF' in the 'MaybeT' monad until it throws 'Nothing'.
-reactimateMaybe :: Monad m => MSF (MaybeT m) () () -> m ()
+reactimateMaybe
+  :: (Functor m, Monad m)
+  => MSF (MaybeT m) () () -> m ()
 reactimateMaybe msf = reactimateExcept $ try $ maybeToExceptS msf
 
 -- | Run an MSF fed from a list, discarding results. Useful when one needs to

--- a/src/Control/Monad/Trans/MSF/Maybe.hs
+++ b/src/Control/Monad/Trans/MSF/Maybe.hs
@@ -8,6 +8,7 @@ The latter viewpoint is most natural in the context of 'MSF's.
 module Control.Monad.Trans.MSF.Maybe
   ( module Control.Monad.Trans.MSF.Maybe
   , module Control.Monad.Trans.Maybe
+  , maybeToExceptS
   ) where
 
 -- External
@@ -15,6 +16,7 @@ import Control.Monad.Trans.Maybe
   hiding (liftCallCC, liftCatch, liftListen, liftPass) -- Avoid conflicting exports
 
 -- Internal
+import Control.Monad.Trans.MSF.Except
 import Control.Monad.Trans.MSF.GenLift
 import Data.MonadicStreamFunction
 
@@ -56,11 +58,9 @@ untilMaybe msf cond = proc a -> do
 
 -- | When an exception occurs in the first 'msf', the second 'msf' is executed from there.
 catchMaybe :: Monad m => MSF (MaybeT m) a b -> MSF m a b -> MSF m a b
-catchMaybe msf1 msf2 = MSF $ \a -> do
-  cont <- runMaybeT $ unMSF msf1 a
-  case cont of
-    Just (b, msf1') -> return (b, msf1' `catchMaybe` msf2)
-    Nothing         -> unMSF msf2 a
+catchMaybe msf1 msf2 = safely $ do
+  _ <- try $ maybeToExceptS msf1
+  safe msf2
 
 -- * Converting to and from 'MaybeT'
 

--- a/src/Control/Monad/Trans/MSF/Maybe.hs
+++ b/src/Control/Monad/Trans/MSF/Maybe.hs
@@ -105,3 +105,13 @@ runMaybeS'' msf = transS transformInput transformOutput msf
         Just (b, msf') -> return (Just b, msf')
         Nothing        -> return (Nothing, msf)
 -}
+
+-- | Reactimates an 'MSF' in the 'MaybeT' monad until it throws 'Nothing'.
+reactimateMaybe :: Monad m => MSF (MaybeT m) () () -> m ()
+reactimateMaybe msf = reactimateExcept $ try $ maybeToExceptS msf
+
+-- | Run an MSF fed from a list, discarding results. Useful when one needs to
+-- combine effects and streams (i.e., for testing purposes).
+embed_ :: (Functor m, Monad m) => MSF m a () -> [a] -> m ()
+
+embed_ msf as = reactimateMaybe $ listToMaybeS as >>> liftMSFTrans msf

--- a/src/Control/Monad/Trans/MSF/State.hs
+++ b/src/Control/Monad/Trans/MSF/State.hs
@@ -50,7 +50,7 @@ runStateS msf = MSF $ \(s, a) -> do
 -- an MSF in the 'State' monad, and outputs the new state with every
 -- transformation step.
 --
--- This sould be always equal to:
+-- This should be always equal to:
 --
 -- @
 -- runStateS_ msf s = feedback s $ runStateS msf >>> arr (\(s,b) -> ((s,b), s))
@@ -67,7 +67,7 @@ runStateS_ msf s = MSF $ \a -> do
 -- | Build an MSF /function/ that takes a fixed state as additional
 -- input, from an MSF in the 'State' monad.
 --
--- This sould be always equal to:
+-- This should be always equal to:
 --
 -- @
 -- runStateS__ msf s = feedback s $ runStateS msf >>> arr (\(s,b) -> (b, s))

--- a/src/Data/MonadicStreamFunction/Async.hs
+++ b/src/Data/MonadicStreamFunction/Async.hs
@@ -60,3 +60,6 @@ concatS msf = MSF $ \_ -> tick msf []
     tick msf' []     = do
       (bs, msf'') <- unMSF msf' ()
       tick msf'' bs
+-- TODO Maybe this can be written more nicely with exceptions?
+-- Similarly takeS :: Int -> MSF m a b -> MSFExcept m a b () throws an exception after n ticks
+-- Or with merge?

--- a/src/Data/MonadicStreamFunction/Core.hs
+++ b/src/Data/MonadicStreamFunction/Core.hs
@@ -123,20 +123,15 @@ liftS = arrM . (liftBase .)
 
 -- | Lift inner monadic actions in monad stacks.
 
--- TODO Should be able to express this in terms of MonadBase
 liftMSFTrans :: (MonadTrans t, Monad m, Monad (t m))
              => MSF m a b
              -> MSF (t m) a b
-liftMSFTrans sf = MSF $ \a -> do
-  (b, sf') <- lift $ unMSF sf a
-  return (b, liftMSFTrans sf')
+liftMSFTrans = liftMSFPurer lift
 
 -- | Lift innermost monadic actions in a monad stacks (generalisation of
 -- 'liftIO').
 liftMSFBase :: (Monad m2, MonadBase m1 m2) => MSF m1 a b -> MSF m2 a b
-liftMSFBase sf = MSF $ \a -> do
-  (b, sf') <- liftBase $ unMSF sf a
-  b `seq` return (b, liftMSFBase sf')
+liftMSFBase = liftMSFPurer liftBase
 
 -- *** Generic MSF Lifting
 

--- a/src/Data/MonadicStreamFunction/Core.hs
+++ b/src/Data/MonadicStreamFunction/Core.hs
@@ -158,18 +158,6 @@ liftMSFPurer liftPurer sf = MSF $ \a -> do
   (b, sf') <- liftPurer $ unMSF sf a
   b `seq` return (b, liftMSFPurer liftPurer sf')
 
--- ** MSFs within monadic actions
-
--- | Extract MSF from a monadic action.
---
--- Runs a monadic action that produces an MSF on the first iteration/step, and
--- uses that MSF as the main signal function for all inputs (including the
--- first one).
-performOnFirstSample :: Monad m => m (MSF m a b) -> MSF m a b
-performOnFirstSample sfaction = MSF $ \a -> do
-  sf <- sfaction
-  unMSF sf a
-
 -- * Delays
 
 -- | Delay a signal by one sample.

--- a/src/Data/MonadicStreamFunction/Core.hs
+++ b/src/Data/MonadicStreamFunction/Core.hs
@@ -223,15 +223,3 @@ reactimate :: Monad m => MSF m () () -> m ()
 reactimate sf = do
   (_, sf') <- unMSF sf ()
   reactimate sf'
-
--- | Run an 'MSF' indefinitely passing a unit-carrying input stream.
--- A more high-level approach to this would be the use of 'MaybeT'
--- in 'Control.Monad.Trans.MSF.Maybe'.
--- | Run an MSF indefinitely passing a unit-carrying input stream.
-
--- TODO: A more high-level approach to this would be the use of MaybeT in
--- Control.Monad.Trans.MSF.Maybe
-reactimateB :: Monad m => MSF m () Bool -> m ()
-reactimateB sf = do
-  (b, sf') <- unMSF sf ()
-  unless b $ reactimateB sf'

--- a/src/Data/MonadicStreamFunction/Util.hs
+++ b/src/Data/MonadicStreamFunction/Util.hs
@@ -92,11 +92,7 @@ iPost b sf = MSF $ \_ -> return (b, sf)
 
 -- | Preprends a fixed output to an MSF, shifting the output.
 next :: Monad m => b -> MSF m a b -> MSF m a b
-next b sf = MSF $ \a -> do
-  (b', sf') <- unMSF sf a
-  return (b, next b' sf')
--- rather, once delay is tested:
--- next b sf = sf >>> delay b
+next b sf = sf >>> delay b
 
 -- | Buffers and returns the elements in FIFO order,
 --   returning 'Nothing' whenever the buffer is empty.
@@ -147,27 +143,17 @@ accumulateWith f s0 = feedback s0 $ arr g
 
 -- | Generate outputs using a step-wise generation function and an initial
 -- value.
-unfold :: Monad m => (a -> (b,a)) -> a -> MSF m () b
-unfold f a = MSF $ \_ -> let (b,a') = f a in b `seq` return (b, unfold f a')
--- unfold f x = feedback x (arr (snd >>> f))
+unfold :: Monad m => (a -> (b, a)) -> a -> MSF m () b
+unfold f a = feedback a (arr (snd >>> f))
 
 -- | Generate outputs using a step-wise generation function and an initial
 -- value. Version of 'unfold' in which the output and the new accumulator
 -- are the same. Should be equal to @\f a -> unfold (f >>> dup) a@.
 repeatedly :: Monad m => (a -> a) -> a -> MSF m () a
-repeatedly f = repeatedly'
- where repeatedly' a = MSF $ \() -> let a' = f a in a' `seq` return (a, repeatedly' a')
--- repeatedly f x = feedback x (arr (f >>> \x -> (x,x)))
+repeatedly f = unfold $ f >>> dup
+  where
+    dup a = (a, a)
 
--- * Running functions
-
--- | Run an MSF fed from a list, discarding results. Useful when one needs to
--- combine effects and streams (i.e., for testing purposes).
-
--- TODO: This is not elementary, it can probably be built using other
--- construts. Move to a non-core module?
-embed_ :: (Functor m, Monad m) => MSF m a () -> [a] -> m ()
-embed_ msf as = void $ foldM (\sf a -> snd <$> unMSF sf a) msf as
 
 -- * Debugging
 

--- a/src/Data/MonadicStreamFunction/Util.hs
+++ b/src/Data/MonadicStreamFunction/Util.hs
@@ -13,6 +13,7 @@ import Prelude hiding (id, (.))
 
 -- Internal
 import Data.MonadicStreamFunction.Core
+import Data.MonadicStreamFunction.Instances.ArrowChoice
 import Data.VectorSpace
 
 -- * Streams and sinks
@@ -62,13 +63,9 @@ mapMSF = MSF . consume
 -- | Apply an MSF to every input. Freezes temporarily if the input is
 -- 'Nothing', and continues as soon as a 'Just' is received.
 mapMaybeS :: Monad m => MSF m a b -> MSF m (Maybe a) (Maybe b)
-mapMaybeS msf = go
-  where
-    go = MSF $ \maybeA -> case maybeA of
-      Just a -> do
-        (b, msf') <- unMSF msf a
-        return (Just b, mapMaybeS msf')
-      Nothing -> return (Nothing, go)
+mapMaybeS msf = proc maybeA -> case maybeA of
+  Just a  -> arr Just <<< msf -< a
+  Nothing -> returnA          -< Nothing
 
 -- * Adding side effects
 


### PR DESCRIPTION
In all places outside core and the wrapping/running functions I removed the MSF constructor. The wrapping/running functions will be handled separately in #16.

This also moves several functions to different modules, because of import cycles.