### PR TITLE
Resolve #71

### DIFF
--- a/src/Control/Arrow/Util.hs
+++ b/src/Control/Arrow/Util.hs
@@ -8,18 +8,6 @@ constantly :: Arrow a => b -> a c b
 constantly = arr . const
 {-# INLINE constantly #-}
 
--- | Alternative implementation of '<<<' that binds more strongly.
-infixr 4 <-<
-(<-<) :: Arrow a => a c d -> a b c -> a b d
-(<-<) = (<<<)
-{-# INLINE (<-<) #-}
-
--- | Alternative implementation of '>>>' that binds more strongly.
-infixr 4 >->
-(>->) :: Arrow a => a b c -> a c d -> a b d
-(>->) = (>>>)
-{-# INLINE (>->) #-}
-
 -- import Control.Category (id)
 -- import Prelude hiding (id)
 


### PR DESCRIPTION
by removing `(<-<)` and `(>->)`. They seem to gave the wrong infixness. See `rhine` where they are also implemented.

I originally asked the question in https://github.com/turion/rhine/issues/16