### PR TITLE
travis: exclude list example in GHC 7.6.3 and discrete example in GHC 8.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ env:
 matrix:
   exclude:
     - ghc: 8.2.1
-    - env: PACKAGEDIR="examples/keerahails"
+      env: PACKAGEDIR="examples/keerahails"
+    - ghc: 7.6.3
+      env: PACKAGEDIR="examples/list"
 
 before_install:
   - cd ${PACKAGEDIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
       env: PACKAGEDIR="examples/keerahails"
     - ghc: 7.6.3
       env: PACKAGEDIR="examples/list"
+    - ghc: 8.2.1
+      env: PACKAGEDIR="examples/discrete"
 
 before_install:
   - cd ${PACKAGEDIR}


### PR DESCRIPTION
`list-t` doesn't build with GHC 7.6.3 (see [this failed job](https://travis-ci.org/ivanperez-keera/dunai/jobs/375996467)) since some module it needs wasn't ported to the corresponding old version of base. Since that's none of our business, it seems best to just exclude it from the build matrix.

When reordering the exclude points, I might have fixed an issue that excluded _all_ GHC 8.2.1 builds and all keerahails builds (I think we want to exclude only the combination of 8.2.1 and keerahails).