### PR TITLE
add is dead

### DIFF
--- a/examples/basic-examples/BasicExamples.hs
+++ b/examples/basic-examples/BasicExamples.hs
@@ -4,10 +4,6 @@ import Data.MonadicStreamFunction
 
 import Text.Read (readMaybe)
 
-
-add :: (Num n, Monad m) => MSF m (n, n) n
-add = arr (\(x, y) -> x + y)
-
 testSerial :: MSF IO () ()
 testSerial =   liftS (\_ -> getLine)
            >>> (arr id &&& arr reverse)


### PR DESCRIPTION
First I wanted to say
``` haskell
add = arr $ uncurry (+)
```
but then I realised that it is not used anywhere.