### PR TITLE
Remove redundant constraint

### DIFF
--- a/src/Data/MonadicStreamFunction/Instances/ArrowLoop.hs
+++ b/src/Data/MonadicStreamFunction/Instances/ArrowLoop.hs
@@ -16,7 +16,7 @@ import Control.Monad.Fix
 
 -- | 'ArrowLoop' instance for MSFs. The monad must be an instance of
 -- 'MonadFix'.
-instance (Monad m, MonadFix m) => ArrowLoop (MSF m) where
+instance MonadFix m => ArrowLoop (MSF m) where
   loop :: MSF m (b, d) (c, d) -> MSF m b c
   loop sf = MSF $ \a -> do
               rec ((b,c), sf') <- unMSF sf (a, c)


### PR DESCRIPTION
`Monad` was always a class constraint on `MonadFix`.