### PR TITLE
Reimplements iPre and safely without MSF constructor

### DIFF
--- a/src/Control/Monad/Trans/MSF/Except.hs
+++ b/src/Control/Monad/Trans/MSF/Except.hs
@@ -166,11 +166,13 @@ data Empty
 
 -- | If no exception can occur, the 'MSF' can be executed without the 'ExceptT' layer.
 safely :: Monad m => MSFExcept m a b Empty -> MSF m a b
-safely (MSFExcept msf) = safely' msf
+safely (MSFExcept msf) = liftMSFPurer fromExcept msf
   where
-    safely' msf = MSF $ \a -> do
-      Right (b, msf') <- runExceptT $ unMSF msf a
-      return (b, safely' msf')
+    fromExcept ma = do
+      -- We can assume that the pattern @Left e@ will not occur,
+      -- since @e@ would have to be of type @Empty@.
+      Right a <- runExceptT ma
+      return a
 
 -- | An 'MSF' without an 'ExceptT' layer never throws an exception,
 --   and can thus have an arbitrary exception type.

--- a/src/Data/MonadicStreamFunction/Core.hs
+++ b/src/Data/MonadicStreamFunction/Core.hs
@@ -58,6 +58,7 @@ import Control.Category (Category(..))
 import Control.Monad
 import Control.Monad.Base
 import Control.Monad.Trans.Class
+import Data.Tuple (swap)
 import Prelude hiding ((.), id, sum)
 
 -- * Definitions
@@ -168,10 +169,7 @@ liftMSFPurer liftPurer sf = MSF $ \a -> do
 iPre :: Monad m
      => a         -- ^ First output
      -> MSF m a a
-iPre firsta = MSF $ \a -> return (firsta, delay a)
--- iPre firsta = feedback firsta $ lift swap
---   where swap (a,b) = (b, a)
--- iPre firsta = next firsta identity
+iPre firsta = feedback firsta $ arr swap
 
 -- | See 'iPre'.
 


### PR DESCRIPTION
Refs #69 .