### PR TITLE
Relax Type-Class Constraints

### DIFF
--- a/src/Control/Monad/Trans/MSF/RWS.hs
+++ b/src/Control/Monad/Trans/MSF/RWS.hs
@@ -23,14 +23,14 @@ import Data.MonadicStreamFunction
 
 
 -- | Wrap an 'MSF' with explicit state variables in 'RWST' monad.
-rwsS :: (Functor m, Monad m, Monoid w)
+rwsS :: (Functor m, Monoid w)
      => MSF m (r, s, a) (w, s, b)
      -> MSF (RWST r w s m) a b
 rwsS = morphGS $ \f a -> RWST $ \r s -> (\((w, s', b), c) -> ((b, c), s', w))
    <$> f (r, s, a)
 
 -- | Run the 'RWST' layer by making the state variables explicit.
-runRWSS :: (Functor m, Monad m, Monoid w)
+runRWSS :: (Functor m, Monoid w)
         => MSF (RWST r w s m) a b
         -> MSF m (r, s, a) (w, s, b)
 runRWSS = morphGS $ \f (r, s, a) -> (\((b, c), s', w) -> ((w, s', b), c))

--- a/src/Control/Monad/Trans/MSF/Reader.hs
+++ b/src/Control/Monad/Trans/MSF/Reader.hs
@@ -25,12 +25,12 @@ import Data.MonadicStreamFunction
 
 -- | Build an 'MSF' in the 'Reader' monad from one that takes the reader
 -- environment as an extra input. This is the opposite of 'runReaderS'.
-readerS :: Monad m => MSF m (r, a) b -> MSF (ReaderT r m) a b
+readerS :: Functor m => MSF m (r, a) b -> MSF (ReaderT r m) a b
 readerS = morphGS $ \f a -> ReaderT $ \r -> f (r, a)
 
 -- | Build an 'MSF' that takes an environment as an extra input from one on the
 -- 'Reader' monad. This is the opposite of 'readerS'.
-runReaderS :: Monad m => MSF (ReaderT r m) a b -> MSF m (r, a) b
+runReaderS :: Functor m => MSF (ReaderT r m) a b -> MSF m (r, a) b
 runReaderS = morphGS $ \f (r, a) -> runReaderT (f a) r
 
 

--- a/src/Control/Monad/Trans/MSF/State.hs
+++ b/src/Control/Monad/Trans/MSF/State.hs
@@ -33,13 +33,13 @@ import Data.MonadicStreamFunction.InternalCore
 
 -- | Build an 'MSF' in the 'State' monad from one that takes the state as an
 -- extra input. This is the opposite of 'runStateS'.
-stateS :: (Functor m, Monad m) => MSF m (s, a) (s, b) -> MSF (StateT s m) a b
+stateS :: Functor m => MSF m (s, a) (s, b) -> MSF (StateT s m) a b
 stateS = morphGS $ \f a -> StateT $ \s -> (\((s', b), c) -> ((b, c), s'))
      <$> f (s, a)
 
 -- | Build an 'MSF' that takes a state as an extra input from one on the
 -- 'State' monad. This is the opposite of 'stateS'.
-runStateS :: (Functor m, Monad m) => MSF (StateT s m) a b -> MSF m (s, a) (s, b)
+runStateS :: Functor m => MSF (StateT s m) a b -> MSF m (s, a) (s, b)
 runStateS = morphGS $ \f (s, a) -> (\((b, c), s') -> ((s', b), c))
         <$> runStateT (f a) s
 

--- a/src/Control/Monad/Trans/MSF/Writer.hs
+++ b/src/Control/Monad/Trans/MSF/Writer.hs
@@ -29,13 +29,13 @@ import Data.MonadicStreamFunction
 
 -- | Build an 'MSF' in the 'Writer' monad from one that produces the log as an
 -- extra output. This is the opposite of 'runWriterS'.
-writerS :: (Functor m, Monad m, Monoid w)
+writerS :: (Functor m, Monoid w)
         => MSF m a (w, b) -> MSF (WriterT w m) a b
 writerS = morphGS $ \f a -> WriterT $ (\((w, b), c) -> ((b, c), w)) <$> f a
 
 -- | Build an 'MSF' that produces the log as an extra output from one on the
 -- 'Writer' monad. This is the opposite of 'writerS'.
-runWriterS :: (Functor m, Monad m)
+runWriterS :: Functor m
            => MSF (WriterT s m) a b -> MSF m a (s, b)
 runWriterS = morphGS $ \f a -> (\((b, c), s) -> ((s, b), c))
          <$> runWriterT (f a)


### PR DESCRIPTION
The functions `morphGS` and `feedback` in the `InternalCore.hs` and `Core.hs` files were constrained to `Monad`. However, they only had a `do` with one bind followed by `return`, which is a `fmap`. We use this to rewrite these functions and relax their type-class constraints from `Monad` to `Functor`.