### PR TITLE
adding video reference from typelevel conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ emosewa si lleksaH
 ^C
 ```
 
-# Further reading
+# Further references
+
+## Reading
 
 The best introduction to the fundamentals of Monadic Stream Functions is:
 
@@ -65,6 +67,9 @@ The following papers are also related to MSFs:
 - [Back to the Future: time travel in FRP](http://dl.acm.org/citation.cfm?id=3122957) ([mirror](http://www.cs.nott.ac.uk/~psxip1/))
 
 - [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/citation.cfm?id=3110246)
+
+## Video
+- [Actors Design Patterns and Arrowised FRP](https://youtu.be/wO_jX8wGhU0?t=781). The minimal implementation of what signal function can be in more declarative approach.
 
 # Structure and internals.
 


### PR DESCRIPTION
As requested in https://github.com/ivanperez-keera/dunai/issues/156

I can't find any implementation mentioned in the slide.

I change the title name and put subsection to differentiate between reading and video.

For additional information, I just watched your talk about Rhine at ICFP 2018, and I think it suits also in dunai's video section. Do you think I should open another commit or put it in this commit?