### PR TITLE
bearriver: Remove extra time step during switches

### DIFF
--- a/examples/bearriver/src/FRP/BearRiver.hs
+++ b/examples/bearriver/src/FRP/BearRiver.hs
@@ -409,14 +409,14 @@ switch :: Monad m => SF m a (b, Event c) -> (c -> SF m a b) -> SF m a b
 switch sf sfC = MSF $ \a -> do
   (o, ct) <- unMSF sf a
   case o of
-    (_, Event c) -> unMSF (sfC c) a
+    (_, Event c) -> local (const 0) (unMSF (sfC c) a)
     (b, NoEvent) -> return (b, switch ct sfC)
 
 dSwitch ::  Monad m => SF m a (b, Event c) -> (c -> SF m a b) -> SF m a b
 dSwitch sf sfC = MSF $ \a -> do
   (o, ct) <- unMSF sf a
   case o of
-    (b, Event c) -> do (_,ct') <- unMSF (sfC c) a
+    (b, Event c) -> do (_,ct') <- local (const 0) (unMSF (sfC c) a)
                        return (b, ct')
     (b, NoEvent) -> return (b, dSwitch ct sfC)
 
@@ -540,8 +540,8 @@ reactimate senseI sense actuate sf = do
  where sfIO        = morphS (return.runIdentity) (runReaderS sf)
 
        -- Sense
-       senseSF     = switch senseFirst senseRest
-       senseFirst  = constM senseI >>> (arr $ \x -> ((0, x), Event x))
+       senseSF     = MSF.switch senseFirst senseRest
+       senseFirst  = constM senseI >>> (arr $ \x -> ((0, x), Just x))
        senseRest a = constM (sense True) >>> (arr id *** keepLast a)
 
        keepLast :: Monad m => a -> MSF m (Maybe a) a
@@ -551,8 +551,6 @@ reactimate senseI sense actuate sf = do
        -- actuateSF :: MSF IO b ()
        -- actuateSF    = arr (\x -> (True, x)) >>> liftMSF (lift . uncurry actuate) >>> exitIf
        actuateSF    = arr (\x -> (True, x)) >>> arrM (uncurry actuate)
-
-       switch sf sfC = MSF.switch (sf >>> second (arr eventToMaybe)) sfC
 
 -- * Debugging / Step by step simulation
 


### PR DESCRIPTION
When I ported some switching signal functions from Yampa to Bear River, I noticed what looked like dropped frames, that is, extra-long time steps.

I realized that `switch` erroneously represents two normal time steps in one: it runs both its first and its second signal function over the same length of time during the switching step. It skips the first output in the second signal function, for which the local time is supposed to be equal to zero.

My solution is to set the first time step of the second signal function to zero using

    local :: Monad m => (DTime -> DTime) -> ReaderT DTime m a -> ReaderT DTime m a

With this change my ported signal functions behave as they did in Yampa.

This change would invalidate any assumptions that the time step is nonzero. For example, `derivative` is just a difference quotient with the time step in the denominator. Its output will be `NaN` or `Infinity` if the step is equal to zero. Also, any signal function whose internal state changes even over a zero time step might skip its second output instead of its first.

I don't think these are big problems. State changes over zero time are bugs to begin with, since they are inconsistent with the continuous-time semantics of signal functions. I believe no primitive signal function in Bear River behaves this way. And Yampa has for a long time warned that `derivative` is risky:

> A very crude version of a derivative. It simply divides the value difference by the time difference. Use at your own risk.

I have never used `derivative`, and I would probably write my own version if the need arose. For convenience's sake Bear River could reasonably provide a `safeDerivative` that checks for the singularity.

For clarity I also slightly reorganized `reactimate` to call `MSF.switch` directly rather than binding an intermediate function to `switch` locally.