### PR TITLE
Add Functor Constraint to untilSF

### DIFF
--- a/extensions/dunai-test/src/FRP/Dunai/LTLPast.hs
+++ b/extensions/dunai-test/src/FRP/Dunai/LTLPast.hs
@@ -36,7 +36,7 @@ sofarSF = feedback True $ arr $ \(n,o) -> let n' = o && n in (n', n')
 everSF :: Monad m => MSF m Bool Bool
 everSF = feedback False $ arr $ \(n,o) -> let n' = o || n in (n', n')
 
-untilSF :: Monad m => MSF m (Bool, Bool) Bool
+untilSF :: (Functor m, Monad m) => MSF m (Bool, Bool) Bool
 untilSF =
     catchMaybe (untilMaybeB (feedback True $ arr cond))
                (snd ^>> sofarSF)


### PR DESCRIPTION
Hi! This adds the `Functor` constraint recommended in #208 for older versions of GHC.