### PR TITLE
Added notice about implementing vector space using linear

### DIFF
--- a/examples/bearriver/src/FRP/Yampa/VectorSpace.hs
+++ b/examples/bearriver/src/FRP/Yampa/VectorSpace.hs
@@ -11,6 +11,9 @@
 --
 -- Vector space type relation and basic instances.
 --
+-- Bearriver does not enforce the use of a particular vector space implementation,
+-- meaning you could use integral for example with other vector types like
+-- V2, V1, etc from linear, see <https://gist.github.com/walseb/1e0a0ca98aaa9469ab5da04e24f482c2 example>
 -----------------------------------------------------------------------------------------
 
 module FRP.Yampa.VectorSpace where


### PR DESCRIPTION
Since `VectorSpace` in bearriver and in yampa are so similar, the same snippet discussed here https://github.com/ivanperez-keera/Yampa/issues/132 works in bearriver also