### PR TITLE
Cabal project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - PACKAGEDIR="."
   - PACKAGEDIR="examples/bearriver"
   - PACKAGEDIR="examples/bouncingball"
+  - PACKAGEDIR="examples/classicfrp"
   - PACKAGEDIR="examples/discrete"
   - PACKAGEDIR="examples/keerahails"
   - PACKAGEDIR="examples/list"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ ghc:
 env:
   - PACKAGEDIR="."
   - PACKAGEDIR="examples/bearriver"
+  - PACKAGEDIR="extensions/dunai-test"
   - PACKAGEDIR="examples/bouncingball"
   - PACKAGEDIR="examples/classicfrp"
   - PACKAGEDIR="examples/discrete"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,47 +13,13 @@ ghc:
   - "8.6.5"
   - "8.8.2"
 
-env:
-  - PACKAGEDIR="."
-  - PACKAGEDIR="examples/bearriver"
-  - PACKAGEDIR="extensions/dunai-test"
-  - PACKAGEDIR="examples/bouncingball"
-  - PACKAGEDIR="examples/classicfrp"
-  - PACKAGEDIR="examples/discrete"
-  - PACKAGEDIR="examples/keerahails"
-  - PACKAGEDIR="examples/list"
-  - PACKAGEDIR="examples/taggingmonad"
-  - PACKAGEDIR="examples/reversefrpzoo/wormholes"
-
-matrix:
-  exclude:
-    - ghc: 7.6.3
-      env: PACKAGEDIR="examples/list"
-    - ghc: 7.8.4
-      env: PACKAGEDIR="examples/discrete"
-    - ghc: 7.8.4
-      env: PACKAGEDIR="examples/keerahails"
-    - ghc: 8.2.2
-      env: PACKAGEDIR="examples/discrete"
-    - ghc: 8.2.2
-      env: PACKAGEDIR="examples/keerahails"
-    - ghc: 8.4.4
-      env: PACKAGEDIR="examples/discrete"
-    - ghc: 8.4.4
-      env: PACKAGEDIR="examples/keerahails"
-    - ghc: 8.6.5
-      env: PACKAGEDIR="examples/discrete"
-    - ghc: 8.6.5
-      env: PACKAGEDIR="examples/keerahails"
-    - ghc: 8.8.2
-      env: PACKAGEDIR="examples/discrete"
-    - ghc: 8.8.2
-      env: PACKAGEDIR="examples/keerahails"
-
 before_install:
-  - cd ${PACKAGEDIR}
   - sudo apt-get update -qq
   - sudo apt-get install -qq libsdl-gfx1.2-dev libwxgtk3.0-dev libbluetooth-dev libcwiid-dev libwxgtk-media3.0-dev libsdl-ttf2.0-dev libwxgtk-webview3.0-dev
+
+script: cabal new-build all && cabal new-test all
+
+install: skip
 
 deploy:
   provider: hackage
@@ -64,4 +30,3 @@ deploy:
     branch: master
     condition:
       - ${TRAVIS_HASKELL_VERSION}=8.6.5
-      - ${PACKAGEDIR} =~ ^(\.|examples/bearriver)$

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: dunai.cabal extensions/dunai-test/dunai-test.cabal examples/*/*.cabal examples/*/*/*.cabal

--- a/examples/classicfrp/GTest.hs
+++ b/examples/classicfrp/GTest.hs
@@ -62,7 +62,7 @@ render (px,py) = do
 
 reactimate' :: Signal Identity (Int, Int) -> IO ()
 reactimate' sf =
-  MSF.reactimate $ sense >>> liftMSFPurer (return.runIdentity) sfIO >>> actuate
+  MSF.reactimate $ sense >>> morphS (return.runIdentity) sfIO >>> actuate
  where sfIO    = runReaderS sf
        sense   = arr (const (0.2, ()))
        actuate = arrM render

--- a/extensions/dunai-test/src/FRP/Dunai/LTLPast.hs
+++ b/extensions/dunai-test/src/FRP/Dunai/LTLPast.hs
@@ -36,7 +36,7 @@ sofarSF = feedback True $ arr $ \(n,o) -> let n' = o && n in (n', n')
 everSF :: Monad m => MSF m Bool Bool
 everSF = feedback False $ arr $ \(n,o) -> let n' = o || n in (n', n')
 
-untilSF :: Monad m => MSF m (Bool, Bool) Bool
+untilSF :: (Functor m, Monad m) => MSF m (Bool, Bool) Bool
 untilSF =
     catchMaybe (untilMaybeB (feedback True $ arr cond))
                (snd ^>> sofarSF)


### PR DESCRIPTION
Supersedes #166. Fixes #205 and #165.

This will probably not work because some packages will fail to build on older GHC versions. My personal opinion is to drop support for these versions, but I understand that you, @ivanperez-keera, want to keep the support. Another possibility might be to fix these packages for those older GHC versions. Might require CPP though.