### PR TITLE
Made MSF and PureGameEnv newtypes.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2020-05-14 Baldur Blöndal <baldurpet@gmail.com>
+	* src:/: Made MSF a newtype.
+
 2020-04-18 Ivan Perez <ivan.perez@keera.co.uk>
         * src:/: Add new utilities. Fix behaviour of listToMaybeS.
         * dunai.cabal: Version bump (0.7.0).

--- a/examples/classicfrp/GTest.hs
+++ b/examples/classicfrp/GTest.hs
@@ -102,7 +102,7 @@ instance GameMonad Identity where
 instance (Functor m, Applicative m, Monad m) => GameMonad (ReaderT PureGameEnv m) where
   getMousePos = pureMousePos <$> ask
 
-data PureGameEnv = PureGameEnv { pureMousePos :: (Int, Int)}
+newtype PureGameEnv = PureGameEnv { pureMousePos :: (Int, Int)}
 
 instance (Functor m, Monad m) => GameMonad (StateT [PureGameEnv] m) where
   getMousePos = StateT $ \ls -> case ls of

--- a/src/Data/MonadicStreamFunction/InternalCore.hs
+++ b/src/Data/MonadicStreamFunction/InternalCore.hs
@@ -55,7 +55,7 @@ import Prelude hiding ((.), id, sum)
 -- 'MSF's should be applied to streams or executed indefinitely or until they
 -- terminate. See 'reactimate' and 'reactimateB' for details. In general,
 -- calling the value constructor 'MSF' or the function 'unMSF' is discouraged.
-data MSF m a b = MSF { unMSF :: a -> m (b, MSF m a b) }
+newtype MSF m a b = MSF { unMSF :: a -> m (b, MSF m a b) }
 
 -- Instances
 


### PR DESCRIPTION
I wanted to test different monoid instances for `MSF`, I tried [`Ap`](https://hackage.haskell.org/package/base-4.12.0.0/docs/src/Data.Monoid.html#Ap) but only the first one worked because `MSF` is defined as a `data` not a `newtype`. Making it a `newtype` means `coerce` and deriving works fully

```haskell
deriving
  via MSF m a `Ap` b
  instance (Monad m, Semigroup b) => Semigroup (MSF m a b)
deriving
  via MSF m a `Ap` b
  instance (Monad m, Monoid b) => Monoid (MSF m a b)
```

vs

```haskell
-- FAILS: MSF f a b is not represented as a function in memory
deriving
  via a -> Ap f (b, MSF f a b)
  instance (Applicative f, Semigroup b) => Semigroup (MSF f a b)
deriving
  via a -> Ap f (b, MSF f a b)
  instance (Applicative f, Monoid b) => Monoid (MSF f a b)
```