### PR TITLE
Travis caching to speed up CI (Fixes #234)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ ghc:
   - "8.6.5"
   - "8.8.2"
 
+cache:
+  directories:
+    - $HOME/.cabal
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libsdl-gfx1.2-dev libbluetooth-dev libcwiid-dev libsdl-ttf2.0-dev


### PR DESCRIPTION
See e.g. https://github.com/turion/essence-of-live-coding/commit/9f96218af2af974cdb40b639734fce1b31661d75 where I've activated caching in a similar project. It largely eradicated the dependency installation phase, which reduced CI build times enormously.