### PR TITLE
Add haskanoid entry to Games section. Refs #227

### DIFF
--- a/dunai/README.md
+++ b/dunai/README.md
@@ -82,6 +82,7 @@ The following papers are also related to MSFs:
 
 ## Games
 - [The Bearriver Arcade](https://github.com/walseb/The_Bearriver_Arcade). Fun arcade games made using bearriver.
+- [Harkanoids](https://github.com/ivanperez-keera/haskanoid). Haskell breakout game implemented using the Functional Reactive Programming library Yampa.
 
 # Structure and internals.
 


### PR DESCRIPTION
Commit ivanperez-keera/haskanoid@cb50205bd8e1ec92eae3b689c1e4f3f2c260367d
added bearriver support to the official haskanoid distribution, making it
a candidate to be listed as a dunai/bearriver game.

Consequently, this commit modifies the README to list haskanoid in the Games section.