### PR TITLE
Add primitives `link` and `vain`

### DIFF
--- a/dunai-frp-bearriver/src/FRP/BearRiver.hs
+++ b/dunai-frp-bearriver/src/FRP/BearRiver.hs
@@ -437,13 +437,6 @@ dSwitch sf sfC = MSF $ \a -> do
                        return (b, ct')
     (b, NoEvent) -> return (b, dSwitch ct sfC)
 
-link' :: Monad m => SF m a (b, Event c) -> (c -> SF m a (b, Event d)) -> SF m a (b, Event d)
-link' sf sfC = MSF $ \a -> do
-  (o, ct) <- unMSF sf a
-  case o of
-    (_, Event c) -> local (const 0) (unMSF (sfC c) a)
-    (b, NoEvent) -> return ((b, NoEvent), link' ct sfC)
-
 link :: Monad m => SF m a (Either b c) -> (c -> SF m a (Either b d)) -> SF m a (Either b d)
 link sf sfC = MSF $ \a -> do
   (o, ct) <- unMSF sf a

--- a/dunai-frp-bearriver/src/FRP/BearRiver.hs
+++ b/dunai-frp-bearriver/src/FRP/BearRiver.hs
@@ -437,12 +437,22 @@ dSwitch sf sfC = MSF $ \a -> do
                        return (b, ct')
     (b, NoEvent) -> return (b, dSwitch ct sfC)
 
-link :: Monad m => SF m a (b, Event c) -> (c -> SF m a (b, Event d)) -> SF m a (b, Event d)
-link sf sfC = MSF $ \a -> do
+link' :: Monad m => SF m a (b, Event c) -> (c -> SF m a (b, Event d)) -> SF m a (b, Event d)
+link' sf sfC = MSF $ \a -> do
   (o, ct) <- unMSF sf a
   case o of
     (_, Event c) -> local (const 0) (unMSF (sfC c) a)
-    (b, NoEvent) -> return ((b, NoEvent), link ct sfC)
+    (b, NoEvent) -> return ((b, NoEvent), link' ct sfC)
+
+link :: Monad m => SF m a (Either b c) -> (c -> SF m a (Either b d)) -> SF m a (Either b d)
+link sf sfC = MSF $ \a -> do
+  (o, ct) <- unMSF sf a
+  case o of
+    Right c -> local (const 0) (unMSF (sfC c) a)
+    Left b  -> return (Left b, link ct sfC)
+
+
+
 
 -- * Parallel composition and switching
 

--- a/dunai-frp-bearriver/src/FRP/BearRiver.hs
+++ b/dunai-frp-bearriver/src/FRP/BearRiver.hs
@@ -444,9 +444,6 @@ link sf sfC = MSF $ \a -> do
     Right c -> local (const 0) (unMSF (sfC c) a)
     Left b  -> return (Left b, link ct sfC)
 
-
-
-
 -- * Parallel composition and switching
 
 -- ** Parallel composition and switching over collections with broadcasting

--- a/dunai/src/Control/Monad/Trans/MSF/Except.hs
+++ b/dunai/src/Control/Monad/Trans/MSF/Except.hs
@@ -273,17 +273,6 @@ switch sf f = catchS ef  f
            (b,me)  <- liftTransS sf -< a
            inExceptT -< ExceptT $ return $ maybe (Right b) Left me
 
-link :: Monad m =>
-        MSF m a (b, Maybe c) -> (c -> MSF m a (b, Maybe d))
-        -> MSF m a (b, Maybe d)
-link sf f = exceptS (handleExceptT (ef sf) (ef . f)) >>> arr pair
-  where
-    pair (Right b)  = (b, Nothing)
-    pair (Left c)   = (undefined, Just c)
-    ef sf           = proc a -> do
-                        (b,me)  <- liftTransS sf -< a
-                        inExceptT -< ExceptT $ return $ maybe (Right b) Left me
-
 -- | More general lifting combinator that enables recovery. Note that, unlike a
 -- polymorphic lifting function @forall a . m a -> m1 a@, this auxiliary
 -- function needs to be a bit more structured, and produces a Maybe value. The

--- a/dunai/src/Control/Monad/Trans/MSF/Except.hs
+++ b/dunai/src/Control/Monad/Trans/MSF/Except.hs
@@ -273,6 +273,17 @@ switch sf f = catchS ef  f
            (b,me)  <- liftTransS sf -< a
            inExceptT -< ExceptT $ return $ maybe (Right b) Left me
 
+link :: Monad m =>
+        MSF m a (b, Maybe c) -> (c -> MSF m a (b, Maybe d))
+        -> MSF m a (b, Maybe d)
+link sf f = exceptS (handleExceptT (ef sf) (ef . f)) >>> arr pair
+  where
+    pair (Right b)  = (b, Nothing)
+    pair (Left c)   = (undefined, Just c)
+    ef sf           = proc a -> do
+                        (b,me)  <- liftTransS sf -< a
+                        inExceptT -< ExceptT $ return $ maybe (Right b) Left me
+
 -- | More general lifting combinator that enables recovery. Note that, unlike a
 -- polymorphic lifting function @forall a . m a -> m1 a@, this auxiliary
 -- function needs to be a bit more structured, and produces a Maybe value. The

--- a/dunai/src/Data/MonadicStreamFunction/Core.hs
+++ b/dunai/src/Data/MonadicStreamFunction/Core.hs
@@ -50,6 +50,7 @@ module Data.MonadicStreamFunction.Core
   , feedback
     -- * Simulation
   , reactimate
+  , vain
   , embed
   , module Control.Arrow
   )
@@ -63,7 +64,7 @@ import Control.Monad.Trans.Class
 import Data.Tuple (swap)
 import Prelude hiding ((.), id, sum)
 
-import Data.MonadicStreamFunction.InternalCore (MSF, morphGS, feedback, reactimate, embed)
+import Data.MonadicStreamFunction.InternalCore (MSF, morphGS, feedback, reactimate, vain, embed)
 
 -- * Definitions
 

--- a/dunai/src/Data/MonadicStreamFunction/InternalCore.hs
+++ b/dunai/src/Data/MonadicStreamFunction/InternalCore.hs
@@ -133,3 +133,8 @@ reactimate :: Monad m => MSF m () () -> m ()
 reactimate sf = do
   (_, sf') <- unMSF sf ()
   reactimate sf'
+
+vain :: Monad m => MSF m a b -> MSF m a (b, MSF m a b)
+vain msf0 = MSF { unMSF = f }
+    where   f a = do    (b, msf1)   <- unMSF msf0 a
+                        return ((b, msf1), vain msf1)

--- a/dunai/src/Data/MonadicStreamFunction/InternalCore.hs
+++ b/dunai/src/Data/MonadicStreamFunction/InternalCore.hs
@@ -134,7 +134,9 @@ reactimate sf = do
   (_, sf') <- unMSF sf ()
   reactimate sf'
 
+-- | Transform an 'MSF' into one with an additional output signal carrying
+-- its current continuation.
 vain :: Monad m => MSF m a b -> MSF m a (b, MSF m a b)
-vain msf0 = MSF { unMSF = f }
-    where   f a = do    (b, msf1)   <- unMSF msf0 a
-                        return ((b, msf1), vain msf1)
+vain msf0 = MSF $ \a -> do
+  (b, msf1) <- unMSF msf0 a
+  return ((b, msf1), vain msf1)


### PR DESCRIPTION
This branch defines a `link`, a new switching primitive for Bear River, and `vain`, a continuation-capturing primitive for Dunai.

These can be used to implement high-level switching facilities as described in [this Haskell Symposium paper][paper]. They serve the same purpose as `Task`s with greater flexibility.

In the future I would recommend changing the official `Task` implementation to use these primitives. This branch, however, simply makes them available to other implementations.

[paper]: https://das.li/scripted-signal-functions.pdf