### PR TITLE
Stop repeatedly from getting stuck in infinite loop. Close #243.

### DIFF
--- a/dunai-frp-bearriver/src/FRP/BearRiver.hs
+++ b/dunai-frp-bearriver/src/FRP/BearRiver.hs
@@ -174,7 +174,7 @@ repeatedly q x
     | q > 0     = afterEach qxs
     | otherwise = error "bearriver: repeatedly: Non-positive period."
   where
-    qxs = (q,x):qxs
+    qxs = (\q' -> (q', x)) <$> scanl (+) q (repeat q)
 
 -- | Event source with consecutive occurrences at the given intervals.
 -- Should more than one event be scheduled to occur in any sampling interval,


### PR DESCRIPTION
#243

I chose to modify repeatedly to fix this, but we could also modify `afterEach` to make it reset its stored time every time an event fires. But I think this would be very unpredictable especially if multiple events fire at the same time, then the timing would be changed for all other future times unless we accumulated the time of the events fired.