### PR TITLE
Update Travis CI badge URLs in README. Refs #254.

### DIFF
--- a/dunai/README.md
+++ b/dunai/README.md
@@ -1,6 +1,6 @@
 # Dunai
 
-[![Build Status](https://travis-ci.org/ivanperez-keera/dunai.svg?branch=develop)](https://travis-ci.org/ivanperez-keera/dunai)
+[![Build Status](https://api.travis-ci.com/ivanperez-keera/dunai.svg?branch=develop)](https://app.travis-ci.com/github/ivanperez-keera/dunai)
 [![Version on Hackage](https://img.shields.io/hackage/v/dunai.svg)](https://hackage.haskell.org/package/dunai)
 
 This repository implements a generalized version of reactive programming, on


### PR DESCRIPTION
The service Travis CI is migrating open source projects from travis-ci.org to
travis-ci.com. Dunai has been migrated among them.

The README.md contains a badge at the top that includes the build status of
dunai. At present, that badge points to the old location on travis-ci.org. The
image is still shown correctly, but the link to the CI page is broken. Both
should be updated.

This commit updates both URLs to point to their new locations under the
travis-ci.com domain.

[ci skip]