### PR TITLE
Update installation instructions in README. Refs #253.

### DIFF
--- a/dunai/README.md
+++ b/dunai/README.md
@@ -10,9 +10,9 @@ be implemented.
 # Installation
 
 ```
-$ cabal sandbox init         # Optional, but recommended
-$ cabal update
-$ cabal install dunai
+$ cabal init
+$ cabal v2-update
+$ cabal v2-install dunai
 ```
 
 ## Dependencies
@@ -132,8 +132,8 @@ You can try it with:
 ```
 git clone https://github.com/ivanperez-keera/haskanoid.git
 cd haskanoid/
-cabal sandbox init
-cabal install -f-wiimote -f-kinect -fbearriver haskanoid/
+cabal init
+cabal v2-install -f-wiimote -f-kinect -fbearriver haskanoid/
 ```
 
 # Related Projects


### PR DESCRIPTION
The README suggests installation instructions that are not up to date with
current versions of Haskell development tools. In particular, they suggest
using `cabal sandbox`, a command that is no longer supported.

This commit modifies the README to provide up-to-date installation
instructions, tested with cabal-install 3.6

[ci skip]