### PR TITLE
Generalize the type of reactInit

### DIFF
--- a/dunai/src/Data/MonadicStreamFunction/ReactHandle.hs
+++ b/dunai/src/Data/MonadicStreamFunction/ReactHandle.hs
@@ -23,7 +23,7 @@ type ReactHandle m = IORef (MSF m () ())
 
 
 -- | Needs to be called before the external main loop is dispatched.
-reactInit :: MonadIO m => MSF m () () -> m (ReactHandle m)
+reactInit :: MonadIO m => MSF n () () -> m (ReactHandle n)
 reactInit = liftIO . newIORef
 
 


### PR DESCRIPTION
slightly generalize the type of reactInit. This allows for passing parameters using ReaderT without passing a parameter when the react handle is created.