### PR TITLE
Fixes #266 - problem with reactimate, adds dswitch to dunai

### DIFF
--- a/dunai-frp-bearriver/bearriver.cabal
+++ b/dunai-frp-bearriver/bearriver.cabal
@@ -60,6 +60,19 @@ description:
   large applications.
 
 
+test-suite regression-tests
+  type: exitcode-stdio-1.0
+  main-is: RegressionTests.hs
+  ghc-options: -Wall
+  hs-source-dirs: tests
+  default-language:  Haskell2010
+  build-depends:
+    base >=4 && <5,
+    transformers,
+    bearriver,
+    tasty,
+    tasty-hunit
+
 source-repository head
   type:     git
   location: git@github.com:ivanperez-keera/dunai.git

--- a/dunai-frp-bearriver/tests/RegressionTests.hs
+++ b/dunai-frp-bearriver/tests/RegressionTests.hs
@@ -1,0 +1,38 @@
+module Main where
+
+-- transformers
+import Control.Monad.Trans.State.Lazy
+
+-- bearriver
+import FRP.Yampa
+
+-- tasty
+import Test.Tasty
+import Test.Tasty.HUnit
+
+main :: IO ()
+main = defaultMain $ testGroup " Reactimate"
+    [ testCase "reactimate where senseRest produces Nothing on first tick" $
+        run senseI senseRest_0 actuate identity @?= [0, 0]
+    , testCase "reactimate where senseRest produces Just a on first tick" $
+        run senseI senseRest_1 actuate identity @?= [0, 99]
+    ] 
+    where
+        run senseI' senseRest' actuate' sf = reverse (snd (flip execState (0,[]) $ reactimate senseI' senseRest' actuate' sf))
+
+senseI :: Monad m => m Int
+senseI = return 0
+
+actuate :: Bool -> Int -> State (Int , [Int]) Bool
+actuate _ x = do
+  (v, xs) <- get
+  put (v+1, x : xs)
+  return (v >= 1)
+
+senseRest_0 :: Monad m => Bool -> m (DTime, Maybe Int)
+senseRest_0 _ = return (0.1, Nothing)
+
+senseRest_1 :: Monad m => Bool -> m (DTime, Maybe Int)
+senseRest_1 _ = return (0.1, Just 99)
+
+

--- a/dunai/src/Control/Monad/Trans/MSF/Except.hs
+++ b/dunai/src/Control/Monad/Trans/MSF/Except.hs
@@ -271,11 +271,24 @@ reactimateB sf = reactimateExcept $ try $ liftTransS sf >>> throwOn ()
 -- Analog to Yampa's [@switch@](https://hackage.haskell.org/package/Yampa/docs/FRP-Yampa-Switches.html#v:switch),
 -- with 'Maybe' instead of @Event@.
 switch :: Monad m => MSF m a (b, Maybe c) -> (c -> MSF m a b) -> MSF m a b
-switch sf f = catchS ef  f
+switch sf f = catchS ef f
   where
     ef = proc a -> do
-           (b,me)  <- liftTransS sf -< a
-           inExceptT -< ExceptT $ return $ maybe (Right b) Left me
+           (b, me)  <- liftTransS sf  -< a
+           throwMaybe                 -< me
+           returnA                    -< b
+
+-- | Run first MSF until the second value in the output tuple is @Just c@ (for
+-- some @c@), then start the second MSF.
+--
+-- Analog to Yampa's [@dswitch@](https://hackage.haskell.org/package/Yampa/docs/FRP-Yampa-Switches.html#v:dSwitch),
+-- with 'Maybe' instead of @Event@.
+dSwitch :: Monad m => MSF m a (b, Maybe c) -> (c -> MSF m a b) -> MSF m a b
+dSwitch sf f = catchS ef f
+  where
+    ef = feedback Nothing $ proc (a, me) -> do
+          throwMaybe    -< me
+          liftTransS sf -< a
 
 -- | More general lifting combinator that enables recovery. Note that, unlike a
 -- polymorphic lifting function @forall a . m a -> m1 a@, this auxiliary


### PR DESCRIPTION
Example code that caused error before this commit:

```Haskell
import Data.IORef
import FRP.Yampa

main = do
  ref <- newIORef (0.0::Double)
  reactimate senseI (senseRest ref) (actuate ref) sf

senseI = do
  putStrLn "SenseI"
  return 45

senseRest ref _ = do
  v <- readIORef ref
  putStrLn "SenseRest"
  return (0.1, Nothing)

actuate ref _ x = do
  v <- readIORef ref
  putStrLn $ "actuate " ++ show x
  writeIORef ref (v+1)
  return (v >= 1)

sf = identity
```