### PR TITLE
removed `seq` from "instance Category (MSF m)" (issue #245)

### DIFF
--- a/dunai/src/Data/MonadicStreamFunction/InternalCore.hs
+++ b/dunai/src/Data/MonadicStreamFunction/InternalCore.hs
@@ -69,7 +69,7 @@ instance Monad m => Category (MSF m) where
     (b, sf1') <- unMSF sf1 a
     (c, sf2') <- unMSF sf2 b
     let sf' = sf2' . sf1'
-    c `seq` return (c, sf')
+    return (c, sf')
 
 -- * Monadic computations and 'MSF's
 


### PR DESCRIPTION
See issue #245. I needed a branch that we can refer to. Shouldn't probably be pushed to develop directly but I don't know how to pull request into a new branch. Please change manually.