### PR TITLE
`bearriver`: make haddock show sections. Refs #322.

### DIFF
--- a/dunai-frp-bearriver/CHANGELOG
+++ b/dunai-frp-bearriver/CHANGELOG
@@ -1,3 +1,6 @@
+2022-09-05 Ivan Perez <ivan.perez@keera.co.uk>
+        * src/BearRiver.hs: show sections in haddock (#322).
+
 2022-08-21 Ivan Perez <ivan.perez@keera.co.uk>
         * bearriver.cabal: Version bump (0.13.6) (#302), add version bounds for
           dependencies (#303).

--- a/dunai-frp-bearriver/src/FRP/BearRiver.hs
+++ b/dunai-frp-bearriver/src/FRP/BearRiver.hs
@@ -8,6 +8,7 @@
 #else
 {-# OPTIONS_GHC -Wno-deprecations #-}
 #endif
+{-# OPTIONS_HADDOCK ignore-exports #-}
 -- Copyright  : (c) Ivan Perez and Manuel Baerenz, 2016
 -- License    : BSD3
 -- Maintainer : ivan.perez@keera.co.uk


### PR DESCRIPTION
This makes the haddock documentation show contents, sections and structure again which I think is much more pleasing. Unfortunately it omits re-exports of other modules (Arrow, MSF, ...). It's arguable which version is a better, but I prefer this one because the links to other modules are still there.

I might not understand Haddock, anyway I filed a bug report here: https://github.com/haskell/haddock/issues/1524