### PR TITLE
dunai: Use correct ListT. Closes #402.

### DIFF
--- a/dunai-examples/classicfrp/classicfrp.cabal
+++ b/dunai-examples/classicfrp/classicfrp.cabal
@@ -20,8 +20,8 @@ executable test
   -- other-modules:
   other-extensions:    Arrows, RankNTypes, FlexibleInstances
   build-depends:       base >=4.6 && <5
-                     , mtl >=2.2 && <2.3
-                     , transformers ==0.5.*
+                     , mtl >=2.2 && <2.4
+                     , transformers >= 0.5 && < 0.7
                      , SDL >=0.6 && <0.7
                      , SDL-gfx >=0.6 && <0.7
                      , dunai
@@ -35,8 +35,8 @@ executable gtest
   -- other-modules:
   other-extensions:    Arrows, RankNTypes, FlexibleInstances
   build-depends:       base >=4.6 && <5
-                     , mtl >=2.2 && <2.3
-                     , transformers ==0.5.*
+                     , mtl >=2.2 && <2.4
+                     , transformers >= 0.5 && < 0.7
                      , SDL >=0.6 && <0.7
                      , SDL-gfx >=0.6 && <0.7
                      , dunai

--- a/dunai-frp-bearriver/bearriver.cabal
+++ b/dunai-frp-bearriver/bearriver.cabal
@@ -99,7 +99,7 @@ library
     , deepseq             >= 1.3.0.0 && < 1.6
     , dunai >= 0.6.0 && < 0.13
     , MonadRandom         >= 0.2   && < 0.7
-    , mtl                 >= 2.1.2 && < 2.3
+    , mtl                 >= 2.1.2 && < 2.4
     , simple-affine-space >= 0.1   && < 0.3
     , transformers >= 0.3 && < 0.7
 

--- a/dunai/dunai.cabal
+++ b/dunai/dunai.cabal
@@ -129,7 +129,6 @@ library
       base >= 4.6 && < 5
     , MonadRandom         >= 0.2 && < 0.7
     , simple-affine-space >= 0.2 && < 0.3
-    , transformers        >= 0.3 && < 0.7
     , transformers-base   >= 0.4 && < 0.5
 
   default-language:
@@ -146,6 +145,15 @@ library
         MonadRandom         >= 0.2 && < 0.6
       , transformers-compat >= 0.3 && < 0.8
       , void                >= 0.1 && < 0.8
+
+  if impl(ghc < 9.6
+    build-depends:
+      transformers        >= 0.3 && < 0.6
+
+  if impl(ghc >= 9.6.0)
+    build-depends:
+        transformers        >= 0.6 && < 0.7
+      , free-listt          >= 0.1.0.1 && < 0.2
 
 test-suite hlint
   type:

--- a/dunai/src/Control/Monad/Trans/MSF/List.hs
+++ b/dunai/src/Control/Monad/Trans/MSF/List.hs
@@ -25,6 +25,8 @@
 -- WARNING: the ListT transformer is considered dangerous, and imposes
 -- additional constraints on the inner monad in order for the combination of
 -- the monad and the transformer to be a monad. Use at your own risk.
+--
+-- From transformers-0.6 on, a valid list monad transformer from free-listt is used.
 module Control.Monad.Trans.MSF.List
     {-# WARNING "This module uses the ListT transformer, which is considered deprecated." #-}
     ( module Control.Monad.Trans.MSF.List


### PR DESCRIPTION
Closes #402 by replacing the removed `ListT` with a valid one starting from GHC 9.6 and `transformers >= 0.6`.