### PR TITLE
Increase version bounds of MonadRandom in bearriver and QuickCheck in dunai-test.

### DIFF
--- a/dunai-frp-bearriver/CHANGELOG
+++ b/dunai-frp-bearriver/CHANGELOG
@@ -1,6 +1,7 @@
-2024-10-13 Ivan Perez <ivan.perez@keera.co.uk>
+2024-10-19 Ivan Perez <ivan.perez@keera.co.uk>
         * Offer all definitions from FRP.Yampa.Switches (#426).
         * Publish embed specialized for FRP.Yampa's SF (#439).
+        * Increase upper bounds on MonadRandom (#436).
 
 2024-08-21 Ivan Perez <ivan.perez@keera.co.uk>
         * Version bump (0.14.10) (#430).

--- a/dunai-frp-bearriver/bearriver.cabal
+++ b/dunai-frp-bearriver/bearriver.cabal
@@ -116,7 +116,7 @@ library
 
   if impl(ghc <= 7.8.4)
     build-depends:
-      MonadRandom >= 0.2 && < 0.6
+      MonadRandom >= 0.2 && < 0.7
 
   if !impl(ghc >= 8.0)
     build-depends:

--- a/dunai-test/CHANGELOG
+++ b/dunai-test/CHANGELOG
@@ -1,3 +1,6 @@
+2024-10-19 Paul Brinkmeier <hallo@pbrinkmeier.de>
+        * Increase upper bounds on QuickCheck (#436).
+
 2024-08-21 Ivan Perez <ivan.perez@keera.co.uk>
         * Version bump (0.13.1) (#430).
 

--- a/dunai-test/dunai-test.cabal
+++ b/dunai-test/dunai-test.cabal
@@ -79,7 +79,7 @@ library
       base >= 4 && < 5
     , dunai >= 0.5 && < 0.14
     , normaldistribution >= 1.0  && < 1.2
-    , QuickCheck         >= 2.12 && < 2.15
+    , QuickCheck         >= 2.12 && < 2.16
 
   default-language:
     Haskell2010


### PR DESCRIPTION
This PR addresses #436. To check if it works, I ran

```
cabal build bearriver --constraint="MonadRandom==0.6"
cabal build dunai-test --constraint="QuickCheck==2.15.0.1"
```

Which are as of today the latest versions matching the new version bounds.