### PR TITLE
bearriver: Remove duplicate loopPre definition. Refs #438.

### DIFF
--- a/dunai-frp-bearriver/CHANGELOG
+++ b/dunai-frp-bearriver/CHANGELOG
@@ -1,7 +1,8 @@
-2024-10-19 Ivan Perez <ivan.perez@keera.co.uk>
+2024-10-21 Ivan Perez <ivan.perez@keera.co.uk>
         * Offer all definitions from FRP.Yampa.Switches (#426).
         * Publish embed specialized for FRP.Yampa's SF (#439).
         * Increase upper bounds on MonadRandom (#436).
+        * Re-export FRP.BearRiver.Loop in FRP.Yampa (#438).
 
 2024-08-21 Ivan Perez <ivan.perez@keera.co.uk>
         * Version bump (0.14.10) (#430).

--- a/dunai-frp-bearriver/src/FRP/Yampa.hs
+++ b/dunai-frp-bearriver/src/FRP/Yampa.hs
@@ -9,8 +9,9 @@ module FRP.Yampa (module X, SF, FutureSF, embed) where
 import Data.Functor.Identity (Identity, runIdentity)
 
 -- Internal imports
-import           FRP.BearRiver as X hiding (FutureSF, SF, embed)
-import qualified FRP.BearRiver as BR
+import           FRP.BearRiver      as X hiding (FutureSF, SF, embed, loopPre)
+import qualified FRP.BearRiver      as BR
+import           FRP.BearRiver.Loop as X
 
 -- | Signal function (conceptually, a function between signals that respects
 -- causality).


### PR DESCRIPTION
Removes the loopPre definition from FRP.BearRiver and replaces it by a re-export from FRP.Yampa.Loop.