### PR TITLE
dunai-examples: Remove duplicated function. Refs #452.

### DIFF
--- a/dunai-examples/list/BouncingBall.hs
+++ b/dunai-examples/list/BouncingBall.hs
@@ -116,6 +116,3 @@ runListMSF msf = runListMSF' [msf]
 -- Auxiliary Arrow functions
 voidI :: Arrow a => a () c -> a b c
 voidI =  (>>>) (arr (const ()))
-
-arr2 :: Arrow a => (b -> c -> d) -> a (b,c) d
-arr2 f = arr (uncurry f)


### PR DESCRIPTION
The example bearriver-examples-bouncingball-list defines a function arr2 equivalent to Yampa's original arr2 function. The fix for issue #360 defined all functions offered by the corresponding Yampa module, so that re-definition as part of the example is no longer necessary. The example no longer compiles for that reason.

This commit removes arr2, so that the function coming from `FRP.Yampa` is used instead.