### PR TITLE
dunai-examples: Fix bug where example hangs on click. Refs #457.

### DIFF
--- a/dunai-examples/list/BouncingBall.hs
+++ b/dunai-examples/list/BouncingBall.hs
@@ -43,6 +43,7 @@ fireballs :: SF (Bool, (Float, Float)) [(Float, Float)]
 fireballs = switch
   (    arr (const [])
    &&& arr (\(mp, pos) -> if mp then Event pos else Yampa.NoEvent)
+   >>> second notYet
   )
 
   (\(p, v) -> let oldfb = voidI $ runListMSF (liftTransS (bouncingBall p v))


### PR DESCRIPTION
Switch is currently stuck in an infinite loop.
`notYet` delays the switch event to the next point in time T(n + 1). The switch will now happen AFTER the event at T(n) has passed.

This issue is described in the [Yampa Arcade
paper](https://dl.acm.org/doi/10.1145/871895.871897) on page 8.

> The resulting signal function is composed with
> `notYet :: SF (Event a) (Event a)`
> that suppresses initial event occurrences.
> Thus the overall result is a source of kill and
> spawn events that will not have
> any occurrence at the point in time when it is
> first activated. This is to prevent gameCore
> from getting stuck in an infinite loop of
> switching.

This does change the semantics of the program
though since the switching now takes place
at T(n + 1) so the program is a little faster.